### PR TITLE
Uses string in python version matrix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     defaults:
       run:


### PR DESCRIPTION
Avoids float representation of 3.10 as 3.1.